### PR TITLE
🐛 修复 UserScript 元数据键名误报

### DIFF
--- a/src/highlight/userScriptDiagnostics.ts
+++ b/src/highlight/userScriptDiagnostics.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode";
  * 用于检测无效的元数据键名并提供修复建议
  */
 
-// 标准 UserScript 元数据键名白名单
+// Tampermonkey UserScript 元数据键名白名单，并保留 ScriptCat 自有扩展键名
 const VALID_META_KEYS = new Set([
   // 核心元数据
   "name",
@@ -13,8 +13,10 @@ const VALID_META_KEYS = new Set([
   "version",
   "description",
   "license",
+  "copyright",
 
   // 脚本关联
+  "defaulticon",
   "icon",
   "iconURL",
   "icon64",
@@ -22,8 +24,10 @@ const VALID_META_KEYS = new Set([
   "updateURL",
   "downloadURL",
   "supportURL",
+  "homepage",
   "homepageURL",
-  "contributionURL",
+  "website",
+  "source",
 
   // 兼容性
   "include",
@@ -38,15 +42,14 @@ const VALID_META_KEYS = new Set([
   "run-at",
   "run-in",
   "inject-into",
+  "sandbox",
+  "webRequest",
   "unwrap",
 
-  // 其他常见键名
+  // 其他 Tampermonkey 键名
   "author",
-  "copyright",
-  "compatible",
-  "incompatible",
   "antifeature",
-  "note",
+  "tag",
 
   // ScriptCat 特有键名
   "early-start",
@@ -55,9 +58,30 @@ const VALID_META_KEYS = new Set([
   "storageName",
 ]);
 
+const LOCALIZABLE_META_KEYS = new Set(["antifeature", "description", "name"]);
+
 // 诊断键名
 const DIAGNOSTIC_SOURCE = "UserScript";
 const INVALID_META_KEY_CODE = "invalid.meta.key";
+
+/**
+ * 判断元数据键名是否为已支持的 UserScript 键名
+ */
+export function isValidMetaKey(key: string): boolean {
+  const colonIndex = key.indexOf(":");
+  if (colonIndex > 0 && LOCALIZABLE_META_KEYS.has(key.slice(0, colonIndex))) {
+    return true;
+  }
+  return VALID_META_KEYS.has(key);
+}
+
+/**
+ * 从一行元数据注释中提取完整键名
+ */
+export function parseMetaKeyFromLine(lineText: string): string | null {
+  const metaMatch = lineText.trim().match(/^\/\/\s+@(\S+)(?:\s+.*?)?$/);
+  return metaMatch ? metaMatch[1] : null;
+}
 
 /**
  * 计算两个字符串的编辑距离（用于拼写建议）
@@ -138,10 +162,9 @@ class UserScriptDiagnosticsProvider implements vscode.CodeActionProvider {
             .map((key) => key.replace(/^@/, ""));
           const line = document.lineAt(diagnostic.range.start.line);
           const trimmedLine = line.text.trim();
-          const metaMatch = trimmedLine.match(/^\/\/\s+@(\w+)/);
+          const invalidKey = parseMetaKeyFromLine(trimmedLine);
 
-          if (metaMatch) {
-            const invalidKey = metaMatch[1];
+          if (invalidKey) {
             const atIndex = line.text.indexOf("@");
             const keyStart = atIndex + 1;
             const keyEnd = keyStart + invalidKey.length;
@@ -211,12 +234,11 @@ class DiagnosticsManager {
 
       // 处理元数据块内的内容
       if (inMetadata) {
-        const metaMatch = trimmedLine.match(/^\/\/\s+@(\w+)(?:\s+(.*?))?$/);
-        if (metaMatch) {
-          const key = metaMatch[1];
+        const key = parseMetaKeyFromLine(trimmedLine);
+        if (key) {
 
           // 检查键名是否有效
-          if (!VALID_META_KEYS.has(key)) {
+          if (!isValidMetaKey(key)) {
             const atIndex = line.indexOf("@");
             const keyStart = atIndex + 1;
             const keyEnd = keyStart + key.length;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -3,6 +3,7 @@ import * as assert from 'assert';
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
 import * as vscode from 'vscode';
+import { isValidMetaKey, parseMetaKeyFromLine } from '../../highlight/userScriptDiagnostics';
 // import * as myExtension from '../../extension';
 
 suite('Extension Test Suite', () => {
@@ -11,5 +12,66 @@ suite('Extension Test Suite', () => {
 	test('Sample test', () => {
 		assert.strictEqual(-1, [1, 2, 3].indexOf(5));
 		assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+	});
+
+	test('应当允许 @homepage 元数据键名', () => {
+		assert.strictEqual(isValidMetaKey('homepage'), true);
+	});
+
+	test('应当允许 Tampermonkey 文档中的元数据键名', () => {
+		const supportedKeys = [
+			'antifeature',
+			'connect',
+			'copyright',
+			'defaulticon',
+			'homepageURL',
+			'run-in',
+			'sandbox',
+			'source',
+			'tag',
+			'webRequest',
+			'website',
+			'unwrap',
+		];
+
+		for (const key of supportedKeys) {
+			assert.strictEqual(isValidMetaKey(key), true, key);
+		}
+	});
+
+	test('应当允许 ScriptCat 自有元数据键名', () => {
+		const supportedKeys = [
+			'background',
+			'crontab',
+			'early-start',
+			'inject-into',
+			'require-css',
+			'storageName',
+		];
+
+		for (const key of supportedKeys) {
+			assert.strictEqual(isValidMetaKey(key), true, key);
+		}
+	});
+
+	test('应当允许本地化元数据键名', () => {
+		assert.strictEqual(isValidMetaKey('name:zh-CN'), true);
+		assert.strictEqual(isValidMetaKey('description:ja'), true);
+		assert.strictEqual(isValidMetaKey('antifeature:en'), true);
+	});
+
+	test('应当解析带连字符与冒号的完整元数据键名', () => {
+		assert.strictEqual(parseMetaKeyFromLine('// @require-css  https://example.com/style.css'), 'require-css');
+		assert.strictEqual(parseMetaKeyFromLine('// @early-start'), 'early-start');
+		assert.strictEqual(parseMetaKeyFromLine('// @name:zh-CN  测试脚本'), 'name:zh-CN');
+	});
+
+	test('应当拒绝未知元数据键名', () => {
+		assert.strictEqual(isValidMetaKey('domain'), false);
+		assert.strictEqual(isValidMetaKey('exclude-match'), false);
+		assert.strictEqual(isValidMetaKey('notAUserScriptKey'), false);
+		assert.strictEqual(isValidMetaKey('oujs:author'), false);
+		assert.strictEqual(isValidMetaKey('uso:script'), false);
+		assert.strictEqual(isValidMetaKey('unknown:locale'), false);
 	});
 });


### PR DESCRIPTION
## 问题

VS Code 扩展的 UserScript metadata 诊断白名单不完整，`@homepage` 会被误报为无效。

Fixes https://github.com/scriptscat/scriptcat/issues/1509
Fixes https://github.com/scriptscat/scriptcat-vscode/issues/25

## 修改

- 按 Tampermonkey 文档中的 Userscript Header key 补齐 `@homepage`、`@website`、`@source`、`@sandbox`、`@webRequest`、`@unwrap` 等字段。
- 保留 ScriptCat 自有元数据键名：`@background`、`@crontab`、`@early-start`、`@inject-into`、`@require-css`、`@storageName`。
- 支持 `@name:zh-CN`、`@description:ja` 等本地化 metadata key。
- 修复诊断解析只匹配 `\w+` 的问题，完整解析带连字符和冒号的 key。
- 增加 metadata key 校验和解析的回归测试，并确认 `oujs:*`、`uso:*` 等非 Tampermonkey 文档字段不会被放行。

## 测试

- `pnpm test`
